### PR TITLE
fix: resolve ESLint/Prettier conflicts and improve code formatting co…

### DIFF
--- a/assets/scripts/partials/_header.js
+++ b/assets/scripts/partials/_header.js
@@ -200,8 +200,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const translations = window.loadTranslations
         ? await window.loadTranslations(newLocale)
         : await fetch(`/${newLocale}/api/translations/${newLocale}`, {
-          headers: { 'X-Requested-With': 'XMLHttpRequest' },
-        }).then(r => r.json());
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+          }).then(r => r.json());
 
       console.log(
         'Translations loaded (cached or fresh):',

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -19,7 +19,7 @@ module.exports = [
       'semi': ['error', 'always'],
       'quotes': ['error', 'single'],
       'no-trailing-spaces': 'error',
-      'indent': ['error', 2],
+      // 'indent': ['error', 2], // Disabled - let Prettier handle indentation
       'comma-dangle': ['error', 'always-multiline'],
     },
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,17 +64,17 @@ Encore
    */
   .cleanupOutputBeforeBuild()
 
-// Displays build status system notifications to the user
-// .enableBuildNotifications()
+  // Displays build status system notifications to the user
+  // .enableBuildNotifications()
 
   .enableSourceMaps(!Encore.isProduction())
   // enables hashed filenames (e.g. app.abc123.css)
   .enableVersioning(Encore.isProduction())
 
-// configure Babel
-// .configureBabel((config) => {
-//     config.plugins.push('@babel/a-babel-plugin');
-// })
+  // configure Babel
+  // .configureBabel((config) => {
+  //     config.plugins.push('@babel/a-babel-plugin');
+  // })
 
   // enables and configure @babel/preset-env polyfills
   .configureBabelPresetEnv(config => {


### PR DESCRIPTION
  - Disable ESLint indent rule to avoid conflicts with Prettier
  - Update npm scripts to include root-level JS files (*.js) in linting/formatting
  - Fix comma-dangle errors in jest.config.js
  - Let Prettier handle all indentation and formatting consistently
  - Prevent recurring CI formatting issue